### PR TITLE
[TASK1] Adds support to create `aws credentils file`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN cd rolesanywhere-credential-helper && \
 
 FROM debian:12-slim
 COPY --from=builder /usr/src/rolesanywhere-credential-helper/build/bin/aws_signing_helper /usr/bin/aws_signing_helper
-ENTRYPOINT ["/usr/bin/aws_signing_helper"]
+COPY ./docker-entrypoint.sh /entrypoint
+RUN chmod +x /entrypoint
+ENTRYPOINT ["/entrypoint"]

--- a/README.MD
+++ b/README.MD
@@ -32,6 +32,29 @@ COPY --from=gcavalcante8808/rolesanywhere-credential-helper:v1.1.1 /usr/bin/aws_
 > Important note: the credentials helper binary is build using the main aws script and thus relies on linux and gblic
 > libraries to work.
 
+### Automatic creation of the `.aws/credentials` file
+
+It's possible to create a `credentials file` automatically by settings the following environment variables:
+
+| Environment Variable        | Description                                                                                       | Default                                                                                                    | Required?                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| CREATE_AWS_CREDENTIALS_FILE | Should the entrypoint create an aws credential file? Any value set here will enable the behavior. | Empty - the file is not created by default.                                                                | NO                                         |
+| CREDENTIALS_FILE_PATH       | Where should the entrypoint create the `credentials` file?                                        | If not provided, `${HOME}/.aws` is assumed, which translates to `/root/.aws` in the default configuration. | NO                                         |
+| CERTIFICATE_FILE_PATH       | Filesystem full path of the PEM public Key.                                                       | N/A                                                                                                        | when `CREATE_AWS_CREDENTIALS_FILE` is set. |
+| CERTIFICATE_KEY_PATH        | Filesystem Full Path of the PEM private key.                                                      | N/A                                                                                                        | when `CREATE_AWS_CREDENTIALS_FILE` is set. |
+| TRUST_ANCHOR_ARN            | AWS Roles Anywhere Trust Anchor ARN.                                                              | N/A                                                                                                        | when `CREATE_AWS_CREDENTIALS_FILE` is set. |
+| PROFILE_ARN                 | AWS Roles Anywhere Trust Profile ARN.                                                             | N/A                                                                                                        | when `CREATE_AWS_CREDENTIALS_FILE` is set. |
+| ROLE_ARN                    | AWS IAM Role ARN.                                                                                 | N/A                                                                                                        | when `CREATE_AWS_CREDENTIALS_FILE` is set. |
+
+The credentials file created use the external authentication format like the one bellow:
+
+```bash
+[default]
+    credential_process = ./aws_signing_helper credential-process --certificate /path/to/certificate --private-key /path/to/private-key --trust-anchor-arn arn:aws:rolesanywhere:region:account:trust-anchor/TA_ID --profile-arn arn:aws:rolesanywhere:region:account:profile/PROFILE_ID --role-arn arn:aws:iam::account:role/role-name-with-path
+```
+
+Check https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html#credential-helper-examples for details regarding the helper command.
+
 ### Author
 
 Author: Gabriel Cavalcante (gabriel.cavalcante88 at gmail.com)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+
+if [[ -n "${CREATE_AWS_CREDENTIALS_FILE:-}" ]]; then
+  LOCATION="${CREDENTIALS_FILE_PATH:-${HOME}/.aws}}"
+  mkdir -p "${LOCATION}"
+
+  cat > "${LOCATION}" <<- EOF
+    [default]
+    credential_process = aws_signing_helper credential-process --certificate ${CERTIFICATE_FILE_PATH?Please set the CERTIFICATE_FILE_PATH variable.} --private-key ${CERTIFICATE_KEY_PATH?Please set the CERTIFICATE_KEY_PATH variable.} --trust-anchor-arn ${TRUST_ANCHOR_ARN?Please set the TRUST_ANCHOR_ARN variable.} --profile-arn ${PROFILE_ARN?Please set the PROFILE_ARN variable.} --role-arn  ${ROLE_ARN?Please set the ROLE variable.}
+EOF
+  echo "Credential file created at ${LOCATION}"
+fi
+
+exec /usr/bin/aws_signing_helper "${@}"


### PR DESCRIPTION
## Scenario

Adds support to create `aws credentils` file suitable to IAM Roles Anywhere use.