### PR TITLE
[TASK2] Build Alpine Image as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.22-bookworm AS builder
+FROM golang:1.22-alpine3.19 AS builder
 ARG VERSION=v1.1.1
 WORKDIR /usr/src
+RUN apk add --no-cache git make gcc musl-dev
 RUN git clone --branch ${VERSION} --depth 1 https://github.com/aws/rolesanywhere-credential-helper.git
 RUN cd rolesanywhere-credential-helper && \
     make release
 
-FROM debian:12-slim
+FROM alpine:3.19
+RUN apk add --no-cache bash
 COPY --from=builder /usr/src/rolesanywhere-credential-helper/build/bin/aws_signing_helper /usr/bin/aws_signing_helper
 COPY ./docker-entrypoint.sh /entrypoint
 RUN chmod +x /entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine3.19 AS builder
+FROM golang:1.22-alpine3.19 AS alpine-builder
 ARG VERSION=v1.1.1
 WORKDIR /usr/src
 RUN apk add --no-cache git make gcc musl-dev
@@ -6,9 +6,22 @@ RUN git clone --branch ${VERSION} --depth 1 https://github.com/aws/rolesanywhere
 RUN cd rolesanywhere-credential-helper && \
     make release
 
-FROM alpine:3.19
+FROM alpine:3.19 AS alpine-target
 RUN apk add --no-cache bash
-COPY --from=builder /usr/src/rolesanywhere-credential-helper/build/bin/aws_signing_helper /usr/bin/aws_signing_helper
+COPY --from=alpine-builder /usr/src/rolesanywhere-credential-helper/build/bin/aws_signing_helper /usr/bin/aws_signing_helper
+COPY ./docker-entrypoint.sh /entrypoint
+RUN chmod +x /entrypoint
+ENTRYPOINT ["/entrypoint"]
+
+FROM golang:1.22-bookworm AS gnu-builder
+ARG VERSION=v1.1.1
+WORKDIR /usr/src
+RUN git clone --branch ${VERSION} --depth 1 https://github.com/aws/rolesanywhere-credential-helper.git
+RUN cd rolesanywhere-credential-helper && \
+    make release
+
+FROM debian:12-slim AS debian-target
+COPY --from=gnu-builder /usr/src/rolesanywhere-credential-helper/build/bin/aws_signing_helper /usr/bin/aws_signing_helper
 COPY ./docker-entrypoint.sh /entrypoint
 RUN chmod +x /entrypoint
 ENTRYPOINT ["/entrypoint"]

--- a/README.MD
+++ b/README.MD
@@ -13,7 +13,7 @@
 <br>
 
 This repository serves as a source for `gcavalcante8808/rolesanywhere-credential-helper` docker image with daily Linux
-builds for arm64 and amd64.
+builds for arm64 and amd64, with Debian and Alpine builds.
 
 ## Usage
 
@@ -21,6 +21,12 @@ You can call the image directly using the following command:
 
 ```bash
 docker run -it --rm gcavalcante8808/rolesanywhere-credential-helper:v1.1.1 version
+```
+
+It's also possible to use an alpine variant:
+
+```bash
+docker run -it --rm gcavalcante8808/rolesanywhere-credential-helper:v1.1.1_alpine3.19 version
 ```
 
 You can also copy the binary in your docker image by using the following statement in your Dockerfile:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,3 +36,4 @@ services:
       target: debian-target
       tags:
         - gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}
+        - gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}_bookworm

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,4 @@
-services:
-  helper:
-    image: gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}
+x-defaults: &defaults
     environment:
       CREATE_AWS_CREDENTIALS_FILE: 1
       CREDENTIALS_FILE_PATH: "/root/.aws/credentials"
@@ -9,14 +7,10 @@ services:
       TRUST_ANCHOR_ARN: arn:aws:rolesanywhere:us-east-1:000000000000:trust-anchor/00000000-0000-0000-0000-000000000000
       PROFILE_ARN: arn:aws:rolesanywhere:us-east-1:000000000000:profile/00000000-0000-0000-0000-000000000000
       ROLE_ARN: arn:aws:iam::000000000000:role/terraform-controller
-    volumes:
-      - ./docker-entrypoint.sh:/entrypoint
     build:
       context: .
-      tags:
-        - gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}
       args:
-        VERSION: ${VERSION:-v1.1.1}
+        VERSION:
       cache_from:
         - type=gha,mode=max
       cache_to:
@@ -27,3 +21,18 @@ services:
           - linux/arm64
     command:
       - version
+
+services:
+  helper-alpine:
+    << : *defaults
+    image: gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}_alpine3.19
+    build:
+      target: alpine-target
+
+  helper-debian:
+    << : *defaults
+    image: gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}_bookworm
+    build:
+      target: debian-target
+      tags:
+        - gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,16 @@
 services:
   helper:
     image: gcavalcante8808/rolesanywhere-credential-helper:${VERSION:-v1.1.1}
+    environment:
+      CREATE_AWS_CREDENTIALS_FILE: 1
+      CREDENTIALS_FILE_PATH: "/root/.aws/credentials"
+      CERTIFICATE_FILE_PATH: "/etc/ira/ssl/tls.crt"
+      CERTIFICATE_KEY_PATH: "/etc/ira/ssl/tls.key"
+      TRUST_ANCHOR_ARN: arn:aws:rolesanywhere:us-east-1:000000000000:trust-anchor/00000000-0000-0000-0000-000000000000
+      PROFILE_ARN: arn:aws:rolesanywhere:us-east-1:000000000000:profile/00000000-0000-0000-0000-000000000000
+      ROLE_ARN: arn:aws:iam::000000000000:role/terraform-controller
+    volumes:
+      - ./docker-entrypoint.sh:/entrypoint
     build:
       context: .
       tags:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 
 if [[ -n "${CREATE_AWS_CREDENTIALS_FILE:-}" ]]; then
+  echo "Create ${CREDENTIALS_FILE_PATH%/*} if needed."
   mkdir -p "${CREDENTIALS_FILE_PATH%/*}"
 
   cat > "${CREDENTIALS_FILE_PATH}" <<- EOF


### PR DESCRIPTION
## Description

Since most infrastructure projects use Alpine and the aws-credentials-helper is very tied to its libc implementation, this PR adds a new image:  gcavalcante8808/rolesanywhere-credential-helper:v1.1.1_alpine3.19.